### PR TITLE
feat: add template function to the standard library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,5 +64,5 @@ jobs:
         run: cargo build
 
       - name: Test
-        run: find tests -name "*.lua" | xargs ./.github/test.sh
-
+        run: find tests -name "*.lua" | xargs -n1 ./.github/test.sh
+        env: { RUST_LOG: debug }

--- a/.github/workflows/ct-commitlint.yml
+++ b/.github/workflows/ct-commitlint.yml
@@ -14,5 +14,8 @@ jobs:
         uses: actions/checkout@v3
         with: {fetch-depth: 1000}
 
+      - name: Git safe.directory
+        run: git config --global --add safe.directory $PWD
+
       - name: Lint commits
         run: conventional-tools commitlint -l1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -105,6 +120,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "liquid",
  "log",
  "reqwest",
  "rlua",
@@ -126,6 +142,41 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -261,6 +312,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -438,6 +499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +520,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -469,6 +549,63 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "liquid"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f55b9db2305857de3b3ceaa0e75cb51a76aaec793875fe152e139cb8fed05c"
+dependencies = [
+ "doc-comment",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93764837aeac37f14b74708cd88a44d82edfa9ad2b1bcd9a3b4d8802fdd9f98"
+dependencies = [
+ "anymap2",
+ "itertools",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926454345f103e8433833077acdbfaa7c3e4b90788d585a8358f02f0b8f5a469"
+dependencies = [
+ "proc-macro2",
+ "proc-quote",
+ "syn",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd06ca30ae026d26ee7fa8596f9590959e2d3726bc5a0f16a21ac4f050ec83c0"
+dependencies = [
+ "itertools",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "time",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "log"
@@ -604,6 +741,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "pest"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha1",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,12 +827,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-quote"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e84ab161de78c915302ca325a19bee6df272800e2ae1a43fe3ef430bab2a100"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "proc-quote-impl",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-quote-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb3ec628b063cdbcf316e06a8b8c1a541d28fa6c0a8eacd2bfb2b7f49e88aa0"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -817,6 +1028,20 @@ name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -842,6 +1067,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +1095,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -898,6 +1140,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -989,6 +1278,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1309,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ log = "0.4.0"
 env_logger = "0.10.0"
 reqwest = { version = "0.11.13", features = ["blocking"] }
 which = "4.3.0"
+liquid = "0.26.0"

--- a/definitions/configz.lua
+++ b/definitions/configz.lua
@@ -73,6 +73,18 @@ configz.run = function(command) end
 ---@return boolean, string
 configz.download = function(destination, config) end
 
+---@class TemplateConfig
+---@field source string The path to the template
+---@field data? any The data that will be available in the template
+
+--- Create a file from a given template.
+--- https://shopify.github.io/liquid/
+---
+---@param destination string
+---@param config TemplateConfig The config for the template
+---@return boolean
+configz.template = function(destination, config) end
+
 -------------------------------------------------------------------------------
 --                                HELPERS
 -------------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use env_logger::{Builder, Target};
 use log::{debug, error, info};
-use rlua::{Context, Error, Function, Lua, Table};
+use rlua::{Context, Error, Function, Lua, Table, Value};
 use std::fs;
 use std::io::Write;
 use std::os::unix;
@@ -18,6 +18,42 @@ struct Args {
 }
 
 struct Configz;
+
+fn to_liquid_object(input: Value) -> liquid::model::Value {
+    match input {
+        Value::Boolean(value) => liquid::model::Value::Scalar(liquid::model::ScalarCow::new(value)),
+        Value::Integer(value) => liquid::model::Value::Scalar(liquid::model::ScalarCow::new(value)),
+        Value::Number(value) => liquid::model::Value::Scalar(liquid::model::ScalarCow::new(value)),
+        Value::String(value) => liquid::model::Value::Scalar(liquid::model::ScalarCow::new(
+            String::from_utf8(value.as_bytes().to_vec()).unwrap(),
+        )),
+        Value::Table(value) => {
+            let is_array = match value.contains_key(1) {
+                Ok(result) => result,
+                Err(_) => false,
+            };
+
+            if is_array {
+                let mut list = Vec::new();
+                for pair in value.pairs::<String, Value>() {
+                    let (_, v) = pair.unwrap();
+                    list.push(to_liquid_object(v))
+                }
+
+                liquid::model::Value::Array(list)
+            } else {
+                let mut table = liquid::model::Object::new();
+                for pair in value.pairs::<String, Value>() {
+                    let (k, v) = pair.unwrap();
+                    table.insert(k.into(), to_liquid_object(v));
+                }
+
+                liquid::model::Value::Object(table)
+            }
+        }
+        _ => liquid::model::Value::Nil,
+    }
+}
 
 impl Configz {
     pub fn debug<'lua>(context: Context<'lua>) -> Function {
@@ -42,6 +78,79 @@ impl Configz {
         context
             .create_function(|_, message: String| {
                 error!("{}", message);
+                Ok(true)
+            })
+            .unwrap()
+    }
+
+    pub fn template<'lua>(context: Context<'lua>) -> Function {
+        context
+            .create_function(|_, (destination, config): (String, Table)| {
+                let template_file: String = match config.get("source") {
+                    Ok(content) => content,
+                    Err(_) => {
+                        error!("[{}] missing required parameter source", destination);
+                        return Ok(false);
+                    }
+                };
+
+                let liquid = match liquid::ParserBuilder::with_stdlib().build() {
+                    Ok(value) => value,
+                    Err(err) => {
+                        error!("[{}] unable to build tempalte engin, {}", destination, err);
+                        return Ok(false);
+                    }
+                };
+
+                let template_content = match fs::read_to_string(&template_file) {
+                    Ok(value) => value,
+                    Err(_) => {
+                        error!(
+                            "[{}] unable to read template file {}",
+                            destination, template_file
+                        );
+                        return Ok(false);
+                    }
+                };
+
+                let template = match liquid.parse(&template_content) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        error!(
+                            "[{}] unable to parse tempalte {} {}",
+                            destination, template_file, err
+                        );
+                        return Ok(false);
+                    }
+                };
+
+                let mut globals = liquid::model::Object::new();
+                let user_data = config.get("data");
+                if user_data.is_ok() {
+                    globals.insert("data".into(), to_liquid_object(user_data.unwrap()));
+                }
+
+                let content = match template.render(&globals) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        error!("[{}] unable to render template {}", destination, err);
+                        return Ok(false);
+                    }
+                };
+
+                let mut file = match fs::File::create(&destination) {
+                    Ok(file) => file,
+                    Err(_) => {
+                        error!("[{}] unable to create the the file", destination);
+                        return Ok(false);
+                    }
+                };
+
+                info!(
+                    "[{}] created from template, {}",
+                    destination, &template_file
+                );
+                file.write_all(&content.as_bytes()).unwrap();
                 Ok(true)
             })
             .unwrap()
@@ -241,6 +350,7 @@ fn main() {
         configz.set("file", Configz::file(lua_ctx)).unwrap();
         configz.set("link", Configz::link(lua_ctx)).unwrap();
         configz.set("download", Configz::download(lua_ctx)).unwrap();
+        configz.set("template", Configz::template(lua_ctx)).unwrap();
         configz
             .set("directory", Configz::directory(lua_ctx))
             .unwrap();

--- a/tests/template.data.liquid
+++ b/tests/template.data.liquid
@@ -1,0 +1,9 @@
+Hello {{data.name}}!
+
+{% if data.bool_one %}Bool one is true{% endif %}
+{% if data.bool_two %}Bool two is true{% endif %}
+
+UserName: {{data.user.name}}
+UserNameLower: {{data.user.name | downcase}}
+
+List: {{data.list | join: ", " }}

--- a/tests/template.liquid
+++ b/tests/template.liquid
@@ -1,0 +1,1 @@
+This is a template

--- a/tests/template.lua
+++ b/tests/template.lua
@@ -1,0 +1,43 @@
+local function test_template(dest, config)
+  local ok = configz.template(dest, config)
+  if not ok then
+    error(string.format([[file("%s") should have returned true]], dest))
+  end
+
+  if not configz.is_file "/tmp/configz/template.txt" then
+    error(string.format([["%s" is not a file]], dest))
+  end
+end
+
+local function read_file(file_path)
+  local file = io.open(file_path, "rb")
+  if file == nil then
+    return false, ""
+  end
+
+  local content = file:read "*all"
+  file:close()
+
+  return true, content
+end
+
+test_template("/tmp/configz/template.txt", { source = "tests/template.liquid" })
+test_template("/tmp/configz/template.data.txt", {
+  source = "tests/template.data.liquid",
+  data = {
+    name = "World",
+    bool_one = false,
+    bool_two = true,
+    user = { name = "The user name" },
+    list = { "one", "two", "three" },
+  },
+})
+
+local file_ok, content = read_file "/tmp/configz/template.data.txt"
+
+assert(file_ok)
+assert(content:find "Hello World!")
+assert(not content:find "Bool one is true")
+assert(content:find "UserName: The user name")
+assert(content:find "UserNameLower: the user name")
+assert(content:find "List: one, two, three")


### PR DESCRIPTION
You can now create a file from a template and render dynamic templates with the liquid templating engine. This adds an extra function called `template` and will take a `source` and optional `data` to render the template.

```lua
configz.template("/tmp/config", { source = "files/config" })
```

This will render the template with no data and save the file to `/tmp/config`. It also supports table data of strings lists and nested tables.

```lua
configz.template("/tmp/config", {
  source = "files/config",
  data = {
    string = "String",
    boolean = boolean,
    nested = { table = "Nested table" },
    list = { "One", "Two", "Three" }
  },
})
```

Ref: #4 