### PR TITLE
fix: exit with an error exit code on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -337,7 +337,7 @@ fn main() {
     debug!("Running module, {}", args.module);
 
     let lua = Lua::new();
-    lua.context(|lua_ctx| {
+    let result = lua.context(|lua_ctx| {
         let configz = lua_ctx.create_table().unwrap();
         let globals = lua_ctx.globals();
 
@@ -368,15 +368,16 @@ fn main() {
 
         globals.set("configz", configz).unwrap();
 
-        let result = lua_ctx
+        lua_ctx
             .load(&format!("require('{}')", args.module).to_string())
-            .exec();
+            .exec()
+    });
 
-        match result {
-            Ok(_) => {}
-            Err(err) => {
-                println!("{}", err);
-            }
+    match result {
+        Ok(_) => std::process::exit(0),
+        Err(err) => {
+            println!("{}", err);
+            std::process::exit(1)
         }
-    })
+    };
 }


### PR DESCRIPTION
The process always exits with a 0 exit code. In this case the tests would never fail. There are obviously many more issues with this.

Now if there is an error thrown in the lua the process will exit with the code of 1.

This will not exit 1 if one of the resource calls fails, an error will need to be thrown on the lua side for this to exit with an error.

```lua
local ok = configz.directory "/some/dir"
assert(ok, "/some/dir was not created successfully")
```

It needs to be done this way because its OK for a `cmd` to exit with an error. For situations you want to test to see if a programme is installed before installing it.