### PR TITLE
Add sha256 sub to the download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "log",
  "reqwest",
  "rlua",
+ "sha256",
  "which",
 ]
 
@@ -363,6 +364,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1075,6 +1082,27 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha256"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f8b5de2bac3a4ae28e9b611072a8e326d9b26c8189c0972d4c321fa684f1f"
+dependencies = [
+ "hex",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ env_logger = "0.10.0"
 reqwest = { version = "0.11.13", features = ["blocking"] }
 which = "4.3.0"
 liquid = "0.26.0"
+sha256 = "1.1.2"

--- a/definitions/configz.lua
+++ b/definitions/configz.lua
@@ -65,6 +65,7 @@ configz.run = function(command) end
 
 ---@class DownloadConfig
 ---@field url string The url to the file that will be downloaded
+---@field sha256? string The sha256 sum of the file you are downloading
 
 --- Download a file from a URL
 ---

--- a/tests/download.lua
+++ b/tests/download.lua
@@ -6,3 +6,10 @@ assert(ok)
 
 local _, content = configz.run "cat /tmp/configz/downloaded-file.liquid"
 assert(content == "This is a template\n")
+
+local sha_download_ok = configz.download("/tmp/configz/downloaded-file.liquid", {
+  url = "https://raw.githubusercontent.com/AdeAttwood/Configz/b2b580e9e678ba7e8688090d34b8625f77d655c3/tests/template.liquid",
+  sha256 = "dfda673284e59eb4aa0865bb9b019f8b6190153377e0ebd3d1675d537128b0a0",
+})
+
+assert(sha_download_ok)


### PR DESCRIPTION
Uses the rust sha256 lib to check the sum of a downloaded file. If the file dose not match the sum it will stop and exit the download.

Ref: #7
